### PR TITLE
make kill messages more consistent across types

### DIFF
--- a/MainPlugin.cs
+++ b/MainPlugin.cs
@@ -51,7 +51,6 @@ public class MainPlugin : IDalamudPlugin
                 case <= 0 when killedLastSecond.TryAdd(entityId, true):
                 {
                     var seStringBuilder = new SeStringBuilder();
-                    seStringBuilder.Append("Killed: ");
                     seStringBuilder.Append(battleCharaPtr->NameString);
                     if (battleCharaPtr->ClassJob > 0)
                     {

--- a/PacketCapture.cs
+++ b/PacketCapture.cs
@@ -78,6 +78,10 @@ internal unsafe class PacketCapture : IDisposable
                             seStringBuilder.Append(MainPlugin.SeStringEvaluator.Service.EvaluateFromAddon(37, [MainPlugin.DataManager.Service.GetExcelSheet<ClassJob>().GetRow(lastDamageGameObject->ClassJob).Abbreviation]));
                             seStringBuilder.Append("!");
                         }
+                        else
+                        {
+                            seStringBuilder.Append("!");
+                        }
                     }
                     else
                     {

--- a/PacketCapture.cs
+++ b/PacketCapture.cs
@@ -76,11 +76,11 @@ internal unsafe class PacketCapture : IDisposable
                         {
                             seStringBuilder.Append(" ");
                             seStringBuilder.Append(MainPlugin.SeStringEvaluator.Service.EvaluateFromAddon(37, [MainPlugin.DataManager.Service.GetExcelSheet<ClassJob>().GetRow(lastDamageGameObject->ClassJob).Abbreviation]));
+                            seStringBuilder.Append("!");
                         }
                     }
                     else
                     {
-                        seStringBuilder.Append("Killed: ");
                         seStringBuilder.Append(battleChara->NameString);
                         if (battleChara->ClassJob > 0)
                         {
@@ -92,7 +92,6 @@ internal unsafe class PacketCapture : IDisposable
                 }
                 else
                 {
-                    seStringBuilder.Append("Killed: ");
                     seStringBuilder.Append(battleChara->NameString);
                     if (battleChara->ClassJob > 0)
                     {


### PR DESCRIPTION
This changes the kill messages from:
`Killed: [target] was killed!`
`[target] was killed by [person who killed]`
to
`[target] was killed!`
`[target] was killed by [person who killed]!`

This makes both more consistent to each other and also gets rid of the redundancy in the former